### PR TITLE
Temporary workaround for Issue #29

### DIFF
--- a/scripts/etcd.sh
+++ b/scripts/etcd.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-echo "installing etcd operator"
-kubectl  create -f https://raw.githubusercontent.com/coreos/etcd-operator/master/example/deployment.yaml
-kubectl  rollout status -f https://raw.githubusercontent.com/coreos/etcd-operator/master/example/deployment.yaml
+echo "installing etcd operator (pinned to v0.4.2)"
+kubectl  create -f https://raw.githubusercontent.com/coreos/etcd-operator/7ff99474ece190a5ece01d15d50c06c03bdf17a4/example/deployment.yaml
+kubectl  rollout status -f https://raw.githubusercontent.com/coreos/etcd-operator/7ff99474ece190a5ece01d15d50c06c03bdf17a4/example/deployment.yaml
 
 until kubectl  get thirdpartyresource cluster.etcd.coreos.com
 do
@@ -13,7 +13,7 @@ done
 echo "pausing for 10 seconds for operator to settle"
 sleep 10
 
-kubectl  create -f https://raw.githubusercontent.com/coreos/etcd-operator/master/example/example-etcd-cluster.yaml
+kubectl  create -f https://raw.githubusercontent.com/coreos/etcd-operator/24eaa92eb4daf7ba569a09499c313d6f78a9e2d8/example/example-etcd-cluster.yaml
 
 echo "installing etcd cluster service"
 kubectl  create -f https://raw.githubusercontent.com/coreos/etcd-operator/master/example/example-etcd-cluster-nodeport-service.json


### PR DESCRIPTION
Issue #29 Correctly points out that etcd v.0.5.0 has a breaking change.  This commit pins the deployment files to this version (which works for me).

Migrating to CRD is best plan going forward; however, this fixes the breakage for now.

Thanks to @jknsware and @mornindew for their work and discoveries on this project.