### PR TITLE
Updating etcd cluster

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -11,7 +11,11 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.4.2
+        image: quay.io/coreos/etcd-operator:v0.9.2
+        command:
+        - etcd-operator
+        # Uncomment to act for resources in all namespaces. More information in doc/clusterwide.md
+        #- -cluster-wide
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/manifests/example-etcd-cluster.yaml
+++ b/manifests/example-etcd-cluster.yaml
@@ -1,7 +1,12 @@
-apiVersion: "etcd.coreos.com/v1beta1"
-kind: "Cluster"
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
 metadata:
   name: "example-etcd-cluster"
+  ## Adding this annotation make this cluster managed by clusterwide operators
+  ## namespaced operators ignore it
+  # annotations:
+  #   etcd.database.coreos.com/scope: clusterwide
 spec:
   size: 3
-  version: "3.1.8"
+  version: "3.2.13"
+

--- a/scripts/etcd.sh
+++ b/scripts/etcd.sh
@@ -4,12 +4,6 @@ echo "installing etcd operator"
 kubectl  create -f manifests/deployment.yaml
 kubectl  rollout status -f manifests/deployment.yaml
 
-until kubectl  get thirdpartyresource cluster.etcd.coreos.com
-do
-    echo "waiting for operator"
-    sleep 2
-done
-
 echo "pausing for 10 seconds for operator to settle"
 sleep 10
 
@@ -19,9 +13,4 @@ echo "installing etcd cluster service"
 kubectl  create -f manifests/service.json
 
 echo "waiting for etcd cluster to turnup"
-
-until kubectl  get pod example-etcd-cluster-0002
-do
-    echo "waiting for etcd cluster to turnup"
-    sleep 2
-done
+sleep 10


### PR DESCRIPTION
@mornindew please take a look.

On the newer versions of kubernetes, you don't have the "thirdpartyresource" type anymore, and the installation script does not work. This was reported here: https://github.com/kenzanlabs/kubernetes-ci-cd/issues/35. Also, I kept getting this error message: `time="2018-05-07T19:30:16Z" level=error msg="initialization failed: fail to create TPR: the server could not find the requested resource"`

I updated the etcd code to use the latest content from https://github.com/coreos/etcd-operator/tree/master/example. Now it starts up without error messages in kubernetes 1.10.