### PR TITLE
hotfix: hello-kenzan image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The proxy’s work is done, so you can go ahead and stop it.
 
 With the image in our cluster registry, the last thing to do is apply the manifest to create and deploy the hello-kenzan pod based on the image.
 
-`kubectl apply -f applications/hello-kenzan/k8s/deployment.yaml`
+`kubectl apply -f applications/hello-kenzan/k8s/manual-deployment.yaml`
 
 #### Step18
 

--- a/applications/hello-kenzan/k8s/manual-deployment.yaml
+++ b/applications/hello-kenzan/k8s/manual-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         tier: hello-kenzan
     spec:
       containers:
-      - image: 127.0.0.1:30400/hello-kenzan:$BUILD_TAG
+      - image: 127.0.0.1:30400/hello-kenzan:latest
         name: hello-kenzan
         ports:
         - containerPort: 80

--- a/part1.yml
+++ b/part1.yml
@@ -53,7 +53,7 @@ parts:
         com: docker stop socat-registry;
 
       - cap: With the image in our cluster registry, the last thing to do is apply the manifest to create and deploy the hello-kenzan pod based on the image.
-        com: kubectl apply -f applications/hello-kenzan/k8s/deployment.yaml
+        com: kubectl apply -f applications/hello-kenzan/k8s/manual-deployment.yaml
 
       - cap: Launch a web browser and view the service.
         com: minikube service hello-kenzan


### PR DESCRIPTION
duplicate hello-kenzan deploy manifest for part1 to be called manually, and update existing manifest for part2 with tag placeholder for jenkins-cd plugin to match and update