### PR TITLE
Patch automatically fixable vulnerabilities in monitor-scale app

### DIFF
--- a/applications/monitor-scale/package.json
+++ b/applications/monitor-scale/package.json
@@ -20,11 +20,11 @@
   "homepage": "https://github.com/kenzanlabs/kubernetes-ci-cd#readme",
   "dependencies": {
     "async": "2.2.0",
-    "body-parser": "1.17.1",
+    "body-parser": "^1.18.3",
     "cors": "2.8.3",
-    "express": "4.15.2",
+    "express": "^4.16.4",
     "node-etcd": "5.0.3",
-    "request": "2.81.0",
+    "request": "^2.88.0",
     "socket.io": "1.7.3"
   }
 }


### PR DESCRIPTION
Used `npm audit fix` to run the updates, which produced the following
report:

```
+ express@4.16.4
+ body-parser@1.18.3
+ request@2.88.0
added 6 packages from 4 contributors, removed 5 packages, updated 28 packages and moved 1 package in 3.081s
fixed 13 of 31 vulnerabilities in 353 scanned packages
  2 package updates for 18 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or refer to `npm audit` for steps to fix these manually)
```

Related to KC-163